### PR TITLE
Allow hash in the error messages

### DIFF
--- a/lint/linter/PhpstanLinter.php
+++ b/lint/linter/PhpstanLinter.php
@@ -140,7 +140,7 @@ final class PhpstanLinter extends ArcanistExternalLinter
     {
         $result = array();
         if (null !== $stdout && '' !== $stdout) {
-            preg_match_all('/[a-zA-Z\/.]+:[0-99999]+:[a-zA-Z\/:_()= \\\\$.0-99999\[\]]+/m', $stdout, $messages);
+            preg_match_all('/[a-zA-Z\/.]+:[0-99999]+:[a-zA-Z\/:_#()= \\\\$.0-99999\[\]]+/m', $stdout, $messages);
             foreach ($messages[0] as $warning) {
                 $message = id(new ArcanistLintMessage())
                     ->setPath($path)


### PR DESCRIPTION
Phpstan has # in the error message.
At the moment it cuts the message before the hash.
 Error  () phpstan violation
    Error: Parameter

After adding the #
 Error  () phpstan violation
    Error: Parameter

              46         $date = new \DateTime();
              47         $manualRefunds = $this->model->findIds(1648363, $date);
              48
    >>>       49         $this->assertNotEmpty(1, count($manualRefunds));
              50     }